### PR TITLE
Upgrade to nom 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ Aggregate Prometheus /metrics endpoint over several Unix socket HTTP endpoints.
 unix_socket = '0.4.5'
 core_mini_http = { git = "https://github.com/hashmismatch/core_mini_http.rs" }
 chunked_transfer = '0.3.1'
-nom = '*'
+nom = '~1.0.0'
 #regex='*'
 #hyper='*'
 #httparse='*'

--- a/src/nom_parsers.rs
+++ b/src/nom_parsers.rs
@@ -30,8 +30,8 @@ fn not_line_ending(c: u8) -> bool {
 
 named!(line_ending, alt!(tag!("\n") | tag!("\r\n")));
 
-named!(metric_metadata(&'a [u8]) -> MetricMetadata<'a>,
-    chain!(
+fn metric_metadata<'a>(input:&'a [u8]) -> IResult<&'a[u8],MetricMetadata<'a>> {
+    chain!(input,
             take_until!("#")        ~
             tag!("# HELP ")         ~
         name: take_while1!(is_metric_name)      ~
@@ -50,7 +50,7 @@ named!(metric_metadata(&'a [u8]) -> MetricMetadata<'a>,
             metric_type: metric_type,
         }
     )
-);
+}
 
 pub fn parse(data: &[u8]) {
     let mut buf = &data[..];


### PR DESCRIPTION
Hi!

nom 1.0 is here, and comes with a few breaking changes. To help the transition, and to test the beta version before release, I took the liberty to test and upgrade (if needed) your code to the 1.0 version. It should work right away, but if there are still issues, or if the code needs to be updated to your latest master, please let me know!

If you want an explanation of the changes, please take a look at the [upgrading documentation](https://github.com/Geal/nom/wiki/Upgrading-to-nom-1.0).

By the way, could you go to one (or all) of those links and write a few kind words about your experience writing parsers in Rust? It would really help me!
- [nom 1.0 release blogpost](https://www.clever-cloud.com/blog/engineering/2015/11/16/nom-1-0/)
- [Reddit post](https://www.reddit.com/r/rust/comments/3t10f3/nom_just_reached_10_cleaner_parsers_more_generic/)
- [Hacker News post](https://news.ycombinator.com/item?id=10574828)

Thank you for using nom!
